### PR TITLE
Fixed: database.yml.example should be a pg config copy

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,25 +1,57 @@
-# MySQL.  Versions 5.0+ are recommended.
+# PostgreSQL. Versions 8.2 and up are supported.
 #
-# Install the MYSQL driver
-#   gem install mysql2
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
 #
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem 'mysql2'
-#
-# And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
+# Configure Using Gemfile
+# gem 'pg'
 #
 default: &default
-  adapter: mysql2
-  encoding: utf8
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
-  username: root
-  password:
-  socket: /tmp/mysql.sock
+  template: template0
 
 development:
   <<: *default
   database: jianggao_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: jianggao
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -40,13 +72,14 @@ test:
 # On Heroku and other platform providers, you may have a full connection URL
 # available as an environment variable. For example:
 #
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
 #
 # You can use this database configuration with:
 #
 #   production:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
+
 production:
   <<: *default
   database: jianggao_production


### PR DESCRIPTION
```
# config/database.yml.example
^b069083 (Martin 2014-10-10 12:33:32 +0800  1) # MySQL.  Versions 5.0+ are recommended.
^b069083 (Martin 2014-10-10 12:33:32 +0800  2) #
^b069083 (Martin 2014-10-10 12:33:32 +0800  3) # Install the MYSQL driver
^b069083 (Martin 2014-10-10 12:33:32 +0800  4) #   gem install mysql2
^b069083 (Martin 2014-10-10 12:33:32 +0800  5) #
```

```
# Gemfile
13b3a62d (Martin      2015-05-29 16:01:24 +0800   6) 
13b3a62d (Martin      2015-05-29 16:01:24 +0800   7) gem 'pg', '~> 0.18.2'
13b3a62d (Martin      2015-05-29 16:01:24 +0800   8) 
```

Since Martin had changed the database from mysql to postgres.