### PR TITLE
set word-break for 'a' tag in the events/slides intro info

### DIFF
--- a/app/assets/stylesheets/frontend/event_details.scss
+++ b/app/assets/stylesheets/frontend/event_details.scss
@@ -87,6 +87,10 @@
       margin: 1em 0;
     }
 
+    a {
+      word-break: break-word;
+    }
+
     h1,
     h2,
     h3,

--- a/app/assets/stylesheets/frontend/slides.scss
+++ b/app/assets/stylesheets/frontend/slides.scss
@@ -145,6 +145,10 @@
     line-height: 20px;
   }
 
+  a {
+    word-break: break-word;
+  }
+
   h1,
   h2,
   h3,


### PR DESCRIPTION
![_-_techparty___openresty_-_ 2016 4 ___blockquote__p_op___](https://cloud.githubusercontent.com/assets/3387572/15005325/d47551c0-11f5-11e6-987b-923a73ea2cb6.png)
