### PR TITLE
[Jianggaowang Exception]slides#destroy (NoMethodError) "undefined method

### DIFF
--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -11,7 +11,7 @@ class Preview < ActiveRecord::Base
   }
 
   def delete_remote_file
-    if remote_file_path?
+    if qiniu_file_path?
       bucket = Qiniu::Config.settings[:bucket]
       RemoteFileDeleteJob.perform_later(bucket, qiniu_file_path)
     end


### PR DESCRIPTION
`remote_file_path?' for #<Preview:0x007ff0b0514...

https://trello.com/c/qSOVshjE/191-jianggaowang-exception-slides-destroy-nomethoderror-undefined-method-remote-file-path-for-preview-0x007ff0b0514